### PR TITLE
Fixed image link

### DIFF
--- a/docs/wiki/v0.4.0 - Lab 7 - Contribution.md
+++ b/docs/wiki/v0.4.0 - Lab 7 - Contribution.md
@@ -301,7 +301,7 @@ To reset these files back to original state, run the following command to connec
 
 1. In your Visual Studio Code, open the `settings.yml` file in the root directory
 
-  <img src="./media/v0.4.0%20-%20Lab7/settingsyaml.png" alt="Settings YAML fork" >
+  <img src="./media/v0.4.0%20-%20Lab7/settingsYaml.png" alt="Settings YAML fork" >
 
 2. Now, open the `settings.yml` of the [`CARML` repository](https://github.com/Azure/ResourceModules/blob/main/settings.yml), copy its content and overwrite it in your local file in VSCode
 


### PR DESCRIPTION
Fixed image link for settingsYaml.png - 'y' was lowercase causing broken image link